### PR TITLE
Support disassociating a WAF (take 2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - node
   - 'lts/*'
 cache: npm
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "11.10.1"
   - 'lts/*'
 cache: npm
 jobs:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ custom:
 |----------|----------|----------|---------|----------------------------------------------------------------|
 | `name`   |  `true`  | `string` |         | The name of the regional WAF to associate the API Gateway with |
 
-### Disssociating a Regional WAF from the API Gateway
+### Disassociating a Regional WAF from the API Gateway
 
 Remove the `associateWaf` element from your custom configurtation and deploy the application. The plugin must stay in the plugins list of `serverless.yml` in order for the WAF to be disassociated.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ custom:
 
 ### Disssociating a Regional WAF from the API Gateway
 
-Remove the `associateWaf` element from your custom configurtation and deploy the application. The plugin must stay in the plugins list of `serverless.yml` in order for the WAS to be disassociated.
+Remove the `associateWaf` element from your custom configurtation and deploy the application. The plugin must stay in the plugins list of `serverless.yml` in order for the WAF to be disassociated.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ plugins:
   - serverless-associate-waf
 ```
 
+### Associating a Regional WAF with the API Gateway
+
 Add your custom configuration:
 
 ```yaml
@@ -29,6 +31,10 @@ custom:
 | Property | Required | Type     | Default | Description                                                    |
 |----------|----------|----------|---------|----------------------------------------------------------------|
 | `name`   |  `true`  | `string` |         | The name of the regional WAF to associate the API Gateway with |
+
+### Disssociating a Regional WAF from the API Gateway
+
+Remove the `associateWaf` element from your custom configurtation and deploy the application. The plugin must stay in the plugins list of `serverless.yml` in order for the WAS to be disassociated.
 
 ## Usage
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,9 +15,7 @@ class AssociateWafPlugin {
 
     this.hooks = {}
 
-    if (this.config.name) {
-      this.hooks['after:deploy:deploy'] = this.associateWaf.bind(this)
-    }
+    this.hooks['after:deploy:deploy'] = this.updateWafAssociation.bind(this)
   }
 
   defaultStackName() {
@@ -26,6 +24,14 @@ class AssociateWafPlugin {
 
   getApiGatewayStageArn(restApiId) {
     return `arn:aws:apigateway:${this.provider.getRegion()}::/restapis/${restApiId}/stages/${this.provider.getStage()}`
+  }
+
+  async updateWafAssociation() {
+    if ((this.config) && (this.config.name) && (this.config.name.trim().length != 0)){
+      await this.associateWaf();
+    } else {
+      await this.disassociateWaf();
+    }
   }
 
   async findWebAclByName(name) {
@@ -87,6 +93,31 @@ class AssociateWafPlugin {
       await this.provider.request('WAFRegional', 'associateWebACL', params)
     } catch (e) {
       console.error(chalk.red(`\n-------- Associate WAF Error --------\n${e.message}`))
+    }
+  }
+
+  async disassociateWaf() {
+    try {
+      const restApiId = await this.getRestApiId()
+      if (!restApiId) {
+        this.serverless.cli.log('Unable to determine REST API ID')
+        return
+      }
+
+      const params = {
+        ResourceArn: this.getApiGatewayStageArn(restApiId)
+      }
+
+      const webACLForResource = await this.provider.request('WAFRegional', 'getWebACLForResource', params)
+      console.log("disassociateWaf: " + JSON.stringify(webACLForResource))
+      if (webACLForResource.WebACLSummary){
+        this.serverless.cli.log('Disassociating WAF...')
+        //params.WebACLId = webACLForResource.WebACLSummary.WebACLId
+        await this.provider.request('WAFRegional', 'disassociateWebACL', params)
+      }
+
+    } catch (e) {
+      console.error(chalk.red(`\n-------- Disassociate WAF Error --------\n${e.message}`))
     }
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -109,10 +109,8 @@ class AssociateWafPlugin {
       }
 
       const webACLForResource = await this.provider.request('WAFRegional', 'getWebACLForResource', params)
-      console.log("disassociateWaf: " + JSON.stringify(webACLForResource))
       if (webACLForResource.WebACLSummary){
         this.serverless.cli.log('Disassociating WAF...')
-        //params.WebACLId = webACLForResource.WebACLSummary.WebACLId
         await this.provider.request('WAFRegional', 'disassociateWebACL', params)
       }
 

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -57,16 +57,16 @@ describe('AssociateWafPlugin', () => {
       expect(plugin.config).toEqual({})
     })
 
-    it('should not set hooks if missing property "custom.associateWaf.name"', () => {
+    it('should set hooks if missing property "custom.associateWaf.name"', () => {
       serverless.service.custom = {
         associateWaf: {}
       }
       plugin = new AssociateWafPlugin(serverless, options)
 
-      expect(plugin.hooks).not.toHaveProperty('after:deploy:deploy')
+      expect(plugin.hooks).toHaveProperty('after:deploy:deploy')
     })
 
-    it('should not set hooks if empty property "custom.associateWaf.name"', () => {
+    it('should set hooks if empty property "custom.associateWaf.name"', () => {
       serverless.service.custom = {
         associateWaf: {
           name: ''
@@ -74,7 +74,7 @@ describe('AssociateWafPlugin', () => {
       }
       plugin = new AssociateWafPlugin(serverless, options)
 
-      expect(plugin.hooks).not.toHaveProperty('after:deploy:deploy')
+      expect(plugin.hooks).toHaveProperty('after:deploy:deploy')
     })
   })
 

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -3,6 +3,8 @@ const Serverless = require('serverless/lib/Serverless')
 const AwsProvider = jest.genMockFromModule('serverless/lib/plugins/aws/provider/awsProvider')
 const CLI = jest.genMockFromModule('serverless/lib/classes/CLI')
 
+const AWSErrorMessage = 'Some AWS provider error'
+
 describe('AssociateWafPlugin', () => {
   let plugin
   let serverless
@@ -34,47 +36,103 @@ describe('AssociateWafPlugin', () => {
   })
 
   describe('without configuration', () => {
-    it('should default to empty config if missing object "custom"', () => {
-      serverless.service.custom = undefined
-      plugin = new AssociateWafPlugin(serverless, options)
 
-      expect(plugin.config).toEqual({})
+    describe('with missing object "custom"', () => {
+      beforeEach(() => {
+        serverless.service.custom = undefined
+        plugin = new AssociateWafPlugin(serverless, options)
+      })
+
+      it('should default to empty config', () => {
+        expect(plugin.config).toEqual({})
+      })
+ 
+      it('should set hooks', () => {
+        expect(plugin.hooks).toHaveProperty('after:deploy:deploy')
+      })
+
+      it('"disassociateWaf()" should be invoked', async () => {
+        await expectDisassociateWafToHaveBeenCalled(plugin)
+      })
+      
+    })
+    
+    describe('with missing object "custom.associateWaf"', () => {
+      beforeEach(() => {
+        serverless.service.custom = {}
+        plugin = new AssociateWafPlugin(serverless, options)
+      })
+      
+      it('should default to empty config', () => {
+        expect(plugin.config).toEqual({})
+      })
+      
+      it('should set hooks', () => {
+        expect(plugin.hooks).toHaveProperty('after:deploy:deploy')
+      })    
+
+      it('"disassociateWaf()" should be invoked', async () => {
+        await expectDisassociateWafToHaveBeenCalled(plugin)
+      })
+      
     })
 
-    it('should default to empty config if missing object "custom.associateWaf"', () => {
-      serverless.service.custom = {}
-      plugin = new AssociateWafPlugin(serverless, options)
-
-      expect(plugin.config).toEqual({})
-    })
-
-    it('should default to empty config if null object "custom.associateWaf"', () => {
-      serverless.service.custom = {
-        associateWaf: null
-      }
-      plugin = new AssociateWafPlugin(serverless, options)
-
-      expect(plugin.config).toEqual({})
-    })
-
-    it('should set hooks if missing property "custom.associateWaf.name"', () => {
-      serverless.service.custom = {
-        associateWaf: {}
-      }
-      plugin = new AssociateWafPlugin(serverless, options)
-
-      expect(plugin.hooks).toHaveProperty('after:deploy:deploy')
-    })
-
-    it('should set hooks if empty property "custom.associateWaf.name"', () => {
-      serverless.service.custom = {
-        associateWaf: {
-          name: ''
+    describe('with null object "custom.associateWaf"', () => {
+      beforeEach(() => {
+        serverless.service.custom = {
+          associateWaf: null
         }
-      }
-      plugin = new AssociateWafPlugin(serverless, options)
+        plugin = new AssociateWafPlugin(serverless, options)
+      })
 
-      expect(plugin.hooks).toHaveProperty('after:deploy:deploy')
+      it('should default to empty config', () => {
+        expect(plugin.config).toEqual({})
+      })
+
+      it('should set hooks', () => {
+        expect(plugin.hooks).toHaveProperty('after:deploy:deploy')
+      })  
+
+      it('"disassociateWaf()" should be invoked', async () => {
+        await expectDisassociateWafToHaveBeenCalled(plugin)
+      })
+  
+    })
+
+    describe('with missing property "custom.associateWaf.name"', () => {
+      beforeEach(() => {
+        serverless.service.custom = {
+          associateWaf: {}
+        }
+        plugin = new AssociateWafPlugin(serverless, options)
+      })
+
+      it('should set hooks if ', () => {
+        expect(plugin.hooks).toHaveProperty('after:deploy:deploy')
+      })
+
+      it('"disassociateWaf()" should be invoked', async () => {
+        await expectDisassociateWafToHaveBeenCalled(plugin)
+      })
+    })
+
+    describe('with empty property "custom.associateWaf.name"', () => {
+      beforeEach(() => {
+        serverless.service.custom = {
+          associateWaf: {
+            name: ''
+          }
+        }
+        plugin = new AssociateWafPlugin(serverless, options)
+      })
+      
+      it('should set hooks if ', () => {
+        expect(plugin.hooks).toHaveProperty('after:deploy:deploy')
+      })
+
+      it('"disassociateWaf()" should be invoked', async () => {
+        await expectDisassociateWafToHaveBeenCalled(plugin)
+      })
     })
   })
 
@@ -95,21 +153,30 @@ describe('AssociateWafPlugin', () => {
     it('should set hooks', () => {
       expect(plugin.hooks).toHaveProperty('after:deploy:deploy')
     })
+
+    it('"associateWaf()" should be invoked', async () => {
+      plugin.associateWaf = jest.fn()
+      plugin.associateWaf.mockResolvedValueOnce({})
+      await plugin.updateWafAssociation()
+      expect(plugin.associateWaf).toHaveBeenCalled()     
+    })
+
   })
 
+  const mockStackResources = {
+    StackResourceSummaries: [
+      {
+        LogicalResourceId: 'some',
+        PhysicalResourceId: 'thing'
+      },
+      {
+        LogicalResourceId: 'ApiGatewayRestApi',
+        PhysicalResourceId: 'theRestApiId'
+      }
+    ]
+  }
+
   describe('associateWaf()', () => {
-    const mockStackResources = {
-      StackResourceSummaries: [
-        {
-          LogicalResourceId: 'some',
-          PhysicalResourceId: 'thing'
-        },
-        {
-          LogicalResourceId: 'ApiGatewayRestApi',
-          PhysicalResourceId: 'theRestApiId'
-        }
-      ]
-    }
 
     beforeEach(() => {
       serverless.service.custom = {
@@ -151,14 +218,9 @@ describe('AssociateWafPlugin', () => {
     })
 
     it('should log error when exception caught', async () => {
-      const spy = jest.spyOn(console, 'error')
-      const errorMessage = 'Some AWS provider error'
-      plugin.provider.request
-        .mockRejectedValueOnce(new Error(errorMessage))
-
-      await plugin.associateWaf()
-
-      expect(spy).toHaveBeenLastCalledWith(expect.stringContaining(errorMessage))
+      spy = await setupAwsErrorMessage(plugin)
+      await plugin.associateWaf()    
+      expect(spy).toHaveBeenLastCalledWith(expect.stringContaining(AWSErrorMessage))
     })
 
     it('should associate WAF', async () => {
@@ -184,4 +246,72 @@ describe('AssociateWafPlugin', () => {
       expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Associating WAF...'))
     })
   })
+
+  describe('disassociateWaf()', () => {
+    beforeEach(() => {
+      serverless.service.custom = {}
+      plugin = new AssociateWafPlugin(serverless, options)
+    })
+
+    it('should log info when unable to find REST API ID from CloudFormation stack', async () => {
+      plugin.provider.request.mockResolvedValueOnce({})
+
+      await plugin.disassociateWaf()
+
+      expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Unable to determine REST API ID'))
+    })
+
+    it('should log error when exception caught', async () => {
+      spy = await setupAwsErrorMessage(plugin)
+      await plugin.disassociateWaf()    
+      expect(spy).toHaveBeenLastCalledWith(expect.stringContaining(AWSErrorMessage))    
+    })
+
+    it('should disassociate WAF if associated', async () => {
+      const mockWebAcls = {
+        WebACLSummary: {
+          WebACLId: 'some-waf-id',
+          Name: 'some-waf-name'
+        }
+      }
+      
+      plugin.provider.request
+        .mockResolvedValueOnce(mockStackResources)
+        .mockResolvedValueOnce(mockWebAcls)
+        .mockResolvedValueOnce({})
+  
+      await plugin.disassociateWaf()
+  
+      expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Disassociating WAF...'))
+    })
+
+    it('should not disassociate WAF if associated', async () => {
+      const mockWebAcls = { }
+      
+      plugin.provider.request
+        .mockResolvedValueOnce(mockStackResources)
+        .mockResolvedValueOnce(mockWebAcls)
+        .mockResolvedValueOnce({})
+  
+      await plugin.disassociateWaf()
+  
+      expect(plugin.serverless.cli.log).not.toHaveBeenLastCalledWith(expect.stringContaining('Disassociating WAF...'))
+    })
+
+  })
+
+  async function setupAwsErrorMessage(plugin){
+    const spy = jest.spyOn(console, 'error')
+    plugin.provider.request
+      .mockRejectedValueOnce(new Error(AWSErrorMessage))
+    return spy
+  }
+
+  async function expectDisassociateWafToHaveBeenCalled(plugin){
+    plugin.disassociateWaf = jest.fn()
+    plugin.disassociateWaf.mockResolvedValueOnce({})
+    await plugin.updateWafAssociation()
+    expect(plugin.disassociateWaf).toHaveBeenCalled() 
+  }
+
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1978,7 +1978,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1999,12 +2000,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2019,17 +2022,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2146,7 +2152,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2158,6 +2165,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2172,6 +2180,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2179,12 +2188,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2203,6 +2214,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2283,7 +2295,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2295,6 +2308,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2380,7 +2394,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2416,6 +2431,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2435,6 +2451,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2478,12 +2495,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },


### PR DESCRIPTION
I noticed that once a WAF is associated, a removal of the associateWaf element from serverless.yml does not trigger a disassociation. This pull request adds the functionality.

Also added the required unit tests and updated README.md.

As agreed, since the [previous PR](https://github.com/MikeSouza/serverless-associate-waf/pull/3) failed due to a bug in NodeJS 11.11.0, I also changed travis.yml to make Trvis run on 11.10.1 instead of latest.