### PR TITLE
Added support for WAFV2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage/
 .serverless/
 
 *.tgz
+.vscode

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ custom:
     version: Regional #(optional) Regional | V2
 ```
 
-| Property | Required | Type     | Default   | Description                                                    |
-|----------|----------|----------|-----------|----------------------------------------------------------------|
-| `name`   |  `true`  | `string` |           | The name of the regional WAF to associate the API Gateway with |
-| `version`|  `false` | `string` | `Regional`| The AWS Waf version to be used|
+| Property | Required | Type     | Default | Description                                                    |
+|----------|----------|----------|---------|----------------------------------------------------------------|
+| `name`   |  `true`  | `string` |         | The name of the regional WAF to associate the API Gateway with |
+| `version`|  `false` | `string` | `Regional`| The AWS WAF version to be used|
 
 ### Disassociating a Regional WAF from the API Gateway
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,13 @@ Add your custom configuration:
 custom:
   associateWaf:
     name: myRegionalWaf
+    version: Regional #(optional) Regional | V2
 ```
 
-| Property | Required | Type     | Default | Description                                                    |
-|----------|----------|----------|---------|----------------------------------------------------------------|
-| `name`   |  `true`  | `string` |         | The name of the regional WAF to associate the API Gateway with |
+| Property | Required | Type     | Default   | Description                                                    |
+|----------|----------|----------|-----------|----------------------------------------------------------------|
+| `name`   |  `true`  | `string` |           | The name of the regional WAF to associate the API Gateway with |
+| `version`|  `false` | `string` | `Regional`| The AWS Waf version to be used|
 
 ### Disassociating a Regional WAF from the API Gateway
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,8 +5,6 @@ const REST_API_ID_KEY = 'ApiGatewayRestApiWaf';
 const DEFAULT_WAF_VERSION = "WAFRegional"
 const DEFAULT_WAF_SCOPE = "REGIONAL"
 
-
-
 const get = (obj, path, defaultValue) => {
   return path.split('.').filter(Boolean).every(step => !(step && !(obj = obj[step]))) ? obj : defaultValue
 }
@@ -21,7 +19,6 @@ class AssociateWafPlugin {
     this.wafVersion = `WAF${this.config.version || "Regional"}` //config.version can be one of [V2, Regional]
     this.wafScope = DEFAULT_WAF_SCOPE //WAFV2 requires a scope setting
     this.verifyValidWafConfig()
-
     this.hooks = {}
 
     this.hooks['after:deploy:deploy'] = this.updateWafAssociation.bind(this)
@@ -44,7 +41,6 @@ class AssociateWafPlugin {
     return `arn:aws:apigateway:${this.provider.getRegion()}::/restapis/${restApiId}/stages/${this.provider.getStage()}`
   }
 
-
   updateCloudFormationTemplate() {
     this.outputRestApiId()
   }
@@ -59,7 +55,7 @@ class AssociateWafPlugin {
   };
 
   async updateWafAssociation() {
-    if ((this.config) && (this.config.name) && (this.config.name.trim().length != 0)) {
+    if ((this.config) && (this.config.name) && (this.config.name.trim().length != 0)){
       await this.associateWaf();
     } else {
       await this.disassociateWaf();
@@ -95,7 +91,7 @@ class AssociateWafPlugin {
 
   async findStackOutputByLogicalId(stackName, logicalId) {
     const response = await this.provider.request('CloudFormation', 'describeStacks', { StackName: stackName })
-    if (response.Stacks) {
+    if(response.Stacks) {
       if (response.Stacks[0].Outputs) {
         for (let resourceSummary of response.Stacks[0].Outputs) {
           if (logicalId === resourceSummary.OutputKey) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,12 +14,19 @@ class AssociateWafPlugin {
 
     this.config = get(this.serverless.service, 'custom.associateWaf', {})
     this.wafVersion = config.version || "WAFRegional"
-
+    this.verifyValidWafVersion()
 
     this.hooks = {}
 
     this.hooks['after:deploy:deploy'] = this.updateWafAssociation.bind(this)
     this.hooks['before:package:finalize'] = this.updateCloudFormationTemplate.bind(this)
+  }
+
+  verifyValidWafVersion() {
+    let validVersions = ["WAFRegional", "WAFV2"]
+    if (!validVersions.includes(this.wafVersion)) {
+      this.wafVersion = "WAFRegional"
+    }
   }
 
   defaultStackName() {

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,6 +13,8 @@ class AssociateWafPlugin {
     this.provider = this.serverless.providers.aws
 
     this.config = get(this.serverless.service, 'custom.associateWaf', {})
+    this.wafVersion = config.version || "WAFRegional"
+
 
     this.hooks = {}
 
@@ -42,7 +44,7 @@ class AssociateWafPlugin {
   };
 
   async updateWafAssociation() {
-    if ((this.config) && (this.config.name) && (this.config.name.trim().length != 0)){
+    if ((this.config) && (this.config.name) && (this.config.name.trim().length != 0)) {
       await this.associateWaf();
     } else {
       await this.disassociateWaf();
@@ -50,7 +52,7 @@ class AssociateWafPlugin {
   }
 
   async findWebAclByName(name) {
-    const response = await this.provider.request('WAFRegional', 'listWebACLs', { Limit: 100 })
+    const response = await this.provider.request(this.wafVersion, 'listWebACLs', { Limit: 100 })
     if (response.WebACLs) {
       for (let webAcl of response.WebACLs) {
         if (name === webAcl.Name) {
@@ -73,7 +75,7 @@ class AssociateWafPlugin {
 
   async findStackOutputByLogicalId(stackName, logicalId) {
     const response = await this.provider.request('CloudFormation', 'describeStacks', { StackName: stackName })
-    if(response.Stacks) {
+    if (response.Stacks) {
       if (response.Stacks[0].Outputs) {
         for (let resourceSummary of response.Stacks[0].Outputs) {
           if (logicalId === resourceSummary.OutputKey) {
@@ -126,7 +128,7 @@ class AssociateWafPlugin {
       }
 
       this.serverless.cli.log('Associating WAF...')
-      await this.provider.request('WAFRegional', 'associateWebACL', params)
+      await this.provider.request(this.wafVersion, 'associateWebACL', params)
     } catch (e) {
       console.error(chalk.red(`\n-------- Associate WAF Error --------\n${e.message}`))
     }
@@ -144,10 +146,10 @@ class AssociateWafPlugin {
         ResourceArn: this.getApiGatewayStageArn(restApiId)
       }
 
-      const webACLForResource = await this.provider.request('WAFRegional', 'getWebACLForResource', params)
-      if (webACLForResource.WebACLSummary){
+      const webACLForResource = await this.provider.request(this.wafVersion, 'getWebACLForResource', params)
+      if (webACLForResource.WebACLSummary) {
         this.serverless.cli.log('Disassociating WAF...')
-        await this.provider.request('WAFRegional', 'disassociateWebACL', params)
+        await this.provider.request(this.wafVersion, 'disassociateWebACL', params)
       }
 
     } catch (e) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,7 @@ class AssociateWafPlugin {
     this.config = get(this.serverless.service, 'custom.associateWaf', {})
 
     this.wafVersion = `WAF${this.config.version || "Regional"}` //config.version can be one of [V2, Regional]
-    this.wafScope = (this.config.scope || "REGIONAL").toUpperCase() //config.scope can be one of [REGIONAL, CLOUDFRONT]
+    this.wafScope = DEFAULT_WAF_SCOPE //WAFV2 requires a scope setting
     this.verifyValidWafConfig()
 
     this.hooks = {}
@@ -30,14 +30,9 @@ class AssociateWafPlugin {
 
   verifyValidWafConfig() {
     const validVersions = [DEFAULT_WAF_VERSION, "WAFV2"] //allowed WAF versions
-    const validScopes = [DEFAULT_WAF_SCOPE, "CLOUDFRONT"] //allowed WAF scopes
     if (!validVersions.includes(this.wafVersion)) {
       this.wafVersion = DEFAULT_WAF_VERSION
       this.serverless.cli.log(`\n-------- Invalid WAF Version Configuration --------\nVersion Defaulted to ${this.wafVersion}`)
-    }
-    if (!validScopes.includes(this.wafScope)) {
-      this.wafScope = DEFAULT_WAF_SCOPE
-      this.serverless.cli.log(`\n-------- Invalid WAF Scope Configuration --------\nScope Defaulted to ${this.wafScope}`)
     }
   }
 
@@ -73,7 +68,7 @@ class AssociateWafPlugin {
 
   async findWebAclByName(name) {
     let params = { Limit: 100 }
-    if (this.wafVersion === "WAFV2") { //WAFV2 requires Scope variable
+    if (this.wafVersion !== DEFAULT_WAF_VERSION) { //WAFV2 requires Scope variable
       params.Scope = this.wafScope
     }
 
@@ -81,7 +76,7 @@ class AssociateWafPlugin {
     if (response.WebACLs) {
       for (let webAcl of response.WebACLs) {
         if (name === webAcl.Name) {
-          return webAcl.WebACLId || webAcl.ARN //WAFV2 uses WebACLArn instead of WebACLId
+          return this.wafVersion === DEFAULT_WAF_VERSION ? webAcl.WebACLId : webAcl.ARN //WAFV2 uses WebACLArn instead of WebACLId
         }
       }
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,10 @@
 
 const chalk = require('chalk')
 const REST_API_ID_KEY = 'ApiGatewayRestApiWaf';
+const DEFAULT_WAF_VERSION = "WAFRegional"
+const DEFAULT_WAF_SCOPE = "REGIONAL"
+
+
 
 const get = (obj, path, defaultValue) => {
   return path.split('.').filter(Boolean).every(step => !(step && !(obj = obj[step]))) ? obj : defaultValue
@@ -13,8 +17,10 @@ class AssociateWafPlugin {
     this.provider = this.serverless.providers.aws
 
     this.config = get(this.serverless.service, 'custom.associateWaf', {})
-    this.wafVersion = config.version || "WAFRegional"
-    this.verifyValidWafVersion()
+
+    this.wafVersion = `WAF${this.config.version || "Regional"}` //config.version can be one of [V2, Regional]
+    this.wafScope = (this.config.scope || "REGIONAL").toUpperCase() //config.scope can be one of [REGIONAL, CLOUDFRONT]
+    this.verifyValidWafConfig()
 
     this.hooks = {}
 
@@ -22,10 +28,16 @@ class AssociateWafPlugin {
     this.hooks['before:package:finalize'] = this.updateCloudFormationTemplate.bind(this)
   }
 
-  verifyValidWafVersion() {
-    let validVersions = ["WAFRegional", "WAFV2"]
+  verifyValidWafConfig() {
+    const validVersions = [DEFAULT_WAF_VERSION, "WAFV2"] //allowed WAF versions
+    const validScopes = [DEFAULT_WAF_SCOPE, "CLOUDFRONT"] //allowed WAF scopes
     if (!validVersions.includes(this.wafVersion)) {
-      this.wafVersion = "WAFRegional"
+      this.wafVersion = DEFAULT_WAF_VERSION
+      this.serverless.cli.log(`\n-------- Invalid WAF Version Configuration --------\nVersion Defaulted to ${this.wafVersion}`)
+    }
+    if (!validScopes.includes(this.wafScope)) {
+      this.wafScope = DEFAULT_WAF_SCOPE
+      this.serverless.cli.log(`\n-------- Invalid WAF Scope Configuration --------\nScope Defaulted to ${this.wafScope}`)
     }
   }
 
@@ -36,6 +48,7 @@ class AssociateWafPlugin {
   getApiGatewayStageArn(restApiId) {
     return `arn:aws:apigateway:${this.provider.getRegion()}::/restapis/${restApiId}/stages/${this.provider.getStage()}`
   }
+
 
   updateCloudFormationTemplate() {
     this.outputRestApiId()
@@ -59,11 +72,16 @@ class AssociateWafPlugin {
   }
 
   async findWebAclByName(name) {
-    const response = await this.provider.request(this.wafVersion, 'listWebACLs', { Limit: 100 })
+    let params = { Limit: 100 }
+    if (this.wafVersion === "WAFV2") { //WAFV2 requires Scope variable
+      params.Scope = this.wafScope
+    }
+
+    const response = await this.provider.request(this.wafVersion, 'listWebACLs', params)
     if (response.WebACLs) {
       for (let webAcl of response.WebACLs) {
         if (name === webAcl.Name) {
-          return webAcl.WebACLId
+          return webAcl.WebACLId || webAcl.ARN //WAFV2 uses WebACLArn instead of WebACLId
         }
       }
     }
@@ -129,10 +147,16 @@ class AssociateWafPlugin {
         return
       }
 
-      const params = {
-        ResourceArn: this.getApiGatewayStageArn(restApiId),
-        WebACLId: webAclId
-      }
+      const params = this.wafVersion === DEFAULT_WAF_VERSION ?
+        {
+          ResourceArn: this.getApiGatewayStageArn(restApiId), //used for WAFRegional
+          WebACLId: webAclId
+        }
+        :
+        {
+          ResourceArn: this.getApiGatewayStageArn(restApiId), //used for WAFV2
+          WebACLArn: webAclId
+        }
 
       this.serverless.cli.log('Associating WAF...')
       await this.provider.request(this.wafVersion, 'associateWebACL', params)
@@ -154,7 +178,7 @@ class AssociateWafPlugin {
       }
 
       const webACLForResource = await this.provider.request(this.wafVersion, 'getWebACLForResource', params)
-      if (webACLForResource.WebACLSummary) {
+      if (webACLForResource.WebACLSummary || webACLForResource.WebACL) { //WAFV2 uses WebACL
         this.serverless.cli.log('Disassociating WAF...')
         await this.provider.request(this.wafVersion, 'disassociateWebACL', params)
       }

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -694,5 +694,5 @@ describe('AssociateWafPlugin', () => {
     await plugin.updateCloudFormationTemplate()
     expect(plugin.outputRestApiId).toHaveBeenCalled()
   }
-
+  
 })

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -9,7 +9,6 @@ const WAF_V2 = "WAFV2"
 const ALLOWED_WAF_VERSIONS = [WAF_REGIONAL, WAF_V2]
 const ALLOWED_WAF_SCOPE = "REGIONAL"
 
-
 describe('AssociateWafPlugin', () => {
   let plugin
   let serverless
@@ -38,12 +37,6 @@ describe('AssociateWafPlugin', () => {
     it('should have access to the serverless instance', () => {
       expect(plugin.serverless).toEqual(serverless)
     })
-
-
-    it('should have access to the serverless instance', () => {
-      expect(plugin.serverless).toEqual(serverless)
-    })
-
     it(`wafVersion should be one of ${ALLOWED_WAF_VERSIONS}`, () => {
       expect(ALLOWED_WAF_VERSIONS).toContain(plugin.wafVersion);
     })
@@ -77,6 +70,7 @@ describe('AssociateWafPlugin', () => {
       it('"disassociateWaf()" should be invoked', async () => {
         await expectDisassociateWafToHaveBeenCalled(plugin)
       })
+
     })
 
     describe('with missing object "custom.associateWaf"', () => {
@@ -181,38 +175,38 @@ describe('AssociateWafPlugin', () => {
       })
     })
 
-    describe('with invalid property "custom.associateWaf.version"', () => {
-      beforeEach(() => {
-        serverless.service.custom = {
-          associateWaf: {
-            version: "invalid-version"
-          }
+  describe('with invalid property "custom.associateWaf.version"', () => {
+    beforeEach(() => {
+      serverless.service.custom = {
+        associateWaf: {
+          version: "invalid-version"
         }
-        plugin = new AssociateWafPlugin(serverless, options)
-      })
-
-      it('should set hooks if ', () => {
-        expect(plugin.hooks).toHaveProperty('after:deploy:deploy')
-        expect(plugin.hooks).toHaveProperty('before:package:finalize')
-      })
-
-      it('should log info when invalid version configuration exists ', () => {
-        expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Invalid WAF Version Configuration'))
-      })
-
-      it(`wafVersion should equal ${WAF_REGIONAL}`, () => {
-        expect(WAF_REGIONAL).toEqual(plugin.wafVersion);
-      })
-
-
-      it('"outputRestApiId()" should be invoked', async () => {
-        await expectOutputRestApiIdToHaveBeenCalled(plugin)
-      })
-
-      it('"disassociateWaf()" should be invoked', async () => {
-        await expectDisassociateWafToHaveBeenCalled(plugin)
-      })
+      }
+      plugin = new AssociateWafPlugin(serverless, options)
     })
+
+    it('should set hooks if ', () => {
+      expect(plugin.hooks).toHaveProperty('after:deploy:deploy')
+      expect(plugin.hooks).toHaveProperty('before:package:finalize')
+    })
+
+    it('should log info when invalid version configuration exists ', () => {
+      expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Invalid WAF Version Configuration'))
+    })
+
+    it(`wafVersion should equal ${WAF_REGIONAL}`, () => {
+      expect(WAF_REGIONAL).toEqual(plugin.wafVersion);
+    })
+
+
+    it('"outputRestApiId()" should be invoked', async () => {
+      await expectOutputRestApiIdToHaveBeenCalled(plugin)
+    })
+
+    it('"disassociateWaf()" should be invoked', async () => {
+      await expectDisassociateWafToHaveBeenCalled(plugin)
+    })
+  })
 
     describe('with null property "custom.associateWaf.version"', () => {
       beforeEach(() => {
@@ -256,7 +250,7 @@ describe('AssociateWafPlugin', () => {
         }
         serverless.service.provider.compiledCloudFormationTemplate = {
           Outputs: [
-            'ApiGatewayRestApiWaf', { Description: 'Rest API Id', Value: 'some-api-rest-id' }]
+            'ApiGatewayRestApiWaf', {Description: 'Rest API Id', Value: 'some-api-rest-id'}]
         }
         plugin = new AssociateWafPlugin(serverless, options)
       })
@@ -296,8 +290,7 @@ describe('AssociateWafPlugin', () => {
           }
         }
         serverless.service.provider.compiledCloudFormationTemplate = {
-          Outputs: [
-            'ApiGatewayRestApiWaf', { Description: 'Rest API Id', Value: 'some-api-rest-id' }]
+          Outputs: ['ApiGatewayRestApiWaf', { Description: 'Rest API Id', Value: 'some-api-rest-id' }]
         }
         plugin = new AssociateWafPlugin(serverless, options)
       })
@@ -341,8 +334,7 @@ describe('AssociateWafPlugin', () => {
           }
         }
         serverless.service.provider.compiledCloudFormationTemplate = {
-          Outputs: [
-            'ApiGatewayRestApiWaf', { Description: 'Rest API Id', Value: 'some-api-rest-id' }]
+          Outputs: ['ApiGatewayRestApiWaf', { Description: 'Rest API Id', Value: 'some-api-rest-id' }]
         }
         plugin = new AssociateWafPlugin(serverless, options)
       })
@@ -418,215 +410,214 @@ describe('AssociateWafPlugin', () => {
   }
 
   describe('associateWaf()', () => {
+
     describe("associate Waf regional", () => {
-      beforeEach(() => {
-        serverless.service.custom = {
-          associateWaf: {
-            name: 'some-waf-name'
-          }
+    beforeEach(() => {
+      serverless.service.custom = {
+        associateWaf: {
+          name: 'some-waf-name'
         }
-        plugin = new AssociateWafPlugin(serverless, options)
-      })
-
-      it('should not lookup REST API ID from CloudFormation stack if specified by provider configuration', async () => {
-        plugin.serverless.service.provider.apiGateway = {
-          restApiId: 'something'
-        }
-        plugin.provider.request.mockResolvedValueOnce({})
-
-        await plugin.associateWaf()
-
-        expect(plugin.provider.request).not.toHaveBeenCalledWith('CloudFormation', expect.anything(), expect.anything())
-      })
-
-      it('should log info when unable to find REST API ID from CloudFormation stack', async () => {
-        plugin.provider.request.mockResolvedValue({})
-
-        await plugin.associateWaf()
-
-        expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Unable to determine REST API ID'))
-      })
-
-      it('should log info when unable to fund REST API ID from stack outputs', async () => {
-        plugin.provider.request.mockResolvedValueOnce({})
-        plugin.provider.request.mockResolvedValueOnce(mockStackMissingOutputs)
-
-        await plugin.associateWaf()
-
-        expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Unable to determine REST API ID'))
-      })
-
-      it('should log info when unable to find WAF', async () => {
-        plugin.provider.request
-          .mockResolvedValueOnce(mockStackResources)
-          .mockResolvedValueOnce(mockStackOutputs)
-          .mockResolvedValueOnce({})
-
-        await plugin.associateWaf()
-
-        expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Unable to find WAF named'))
-      })
-
-      it('should log error when exception caught', async () => {
-        spy = await setupAwsErrorMessage(plugin)
-        await plugin.associateWaf()
-        expect(spy).toHaveBeenLastCalledWith(expect.stringContaining(AWSErrorMessage))
-      })
-
-      it('should associate WAF', async () => {
-        const mockWebAcls = {
-          WebACLs: [
-            {
-              Name: 'skip-waf-name',
-              WebACLId: 'skip-waf-id'
-            },
-            {
-              Name: 'some-waf-name',
-              WebACLId: 'some-waf-id'
-            }
-          ]
-        }
-
-        plugin.provider.request
-          .mockResolvedValueOnce(mockStackResources)
-          .mockResolvedValueOnce(mockWebAcls)
-
-        await plugin.associateWaf()
-
-        expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Associating WAF...'))
-      })
-
-      it('should associate WAF with split stacks plugin', async () => {
-        const mockWebAcls = {
-          WebACLs: [
-            {
-              Name: 'skip-waf-name',
-              WebACLId: 'skip-waf-id'
-            },
-            {
-              Name: 'some-waf-name',
-              WebACLId: 'some-waf-id'
-            }
-          ]
-        }
-
-        plugin.provider.request
-          .mockResolvedValueOnce({})
-          .mockResolvedValueOnce(mockStackOutputs)
-          .mockResolvedValueOnce(mockWebAcls)
-
-        await plugin.associateWaf()
-
-        expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Associating WAF...'))
-      })
+      }
+      plugin = new AssociateWafPlugin(serverless, options)
     })
 
+    it('should not lookup REST API ID from CloudFormation stack if specified by provider configuration', async () => {
+      plugin.serverless.service.provider.apiGateway = {
+        restApiId: 'something'
+      }
+      plugin.provider.request.mockResolvedValueOnce({})
 
+      await plugin.associateWaf()
+
+      expect(plugin.provider.request).not.toHaveBeenCalledWith('CloudFormation', expect.anything(), expect.anything())
+    })
+
+    it('should log info when unable to find REST API ID from CloudFormation stack', async () => {
+      plugin.provider.request.mockResolvedValue({})
+
+      await plugin.associateWaf()
+
+      expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Unable to determine REST API ID'))
+    })
+
+    it('should log info when unable to fund REST API ID from stack outputs', async () => {
+      plugin.provider.request.mockResolvedValueOnce({})
+      plugin.provider.request.mockResolvedValueOnce(mockStackMissingOutputs)
+
+      await plugin.associateWaf()
+
+      expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Unable to determine REST API ID'))
+    })
+
+    it('should log info when unable to find WAF', async () => {
+      plugin.provider.request
+        .mockResolvedValueOnce(mockStackResources)
+        .mockResolvedValueOnce(mockStackOutputs)
+        .mockResolvedValueOnce({})
+
+      await plugin.associateWaf()
+
+      expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Unable to find WAF named'))
+    })
+
+    it('should log error when exception caught', async () => {
+      spy = await setupAwsErrorMessage(plugin)
+      await plugin.associateWaf()
+      expect(spy).toHaveBeenLastCalledWith(expect.stringContaining(AWSErrorMessage))
+    })
+
+    it('should associate WAF', async () => {
+      const mockWebAcls = {
+        WebACLs: [
+          {
+            Name: 'skip-waf-name',
+            WebACLId: 'skip-waf-id'
+          },
+          {
+            Name: 'some-waf-name',
+            WebACLId: 'some-waf-id'
+          }
+        ]
+      }
+
+      plugin.provider.request
+        .mockResolvedValueOnce(mockStackResources)
+        .mockResolvedValueOnce(mockWebAcls)
+
+      await plugin.associateWaf()
+
+      expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Associating WAF...'))
+    })
+
+    it('should associate WAF with split stacks plugin', async () => {
+      const mockWebAcls = {
+        WebACLs: [
+          {
+            Name: 'skip-waf-name',
+            WebACLId: 'skip-waf-id'
+          },
+          {
+            Name: 'some-waf-name',
+            WebACLId: 'some-waf-id'
+          }
+        ]
+      }
+
+      plugin.provider.request
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce(mockStackOutputs)
+        .mockResolvedValueOnce(mockWebAcls)
+
+      await plugin.associateWaf()
+
+      expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Associating WAF...'))
+    })
+    })
 
     describe("associate Waf V2", () => {
-      beforeEach(() => {
-        serverless.service.custom = {
-          associateWaf: {
-            name: 'some-waf-name',
-            version: "V2"
-          }
+    beforeEach(() => {
+      serverless.service.custom = {
+        associateWaf: {
+          name: 'some-waf-name',
+          version: "V2"
         }
-        plugin = new AssociateWafPlugin(serverless, options)
-      })
-
-      it('should not lookup REST API ID from CloudFormation stack if specified by provider configuration', async () => {
-        plugin.serverless.service.provider.apiGateway = {
-          restApiId: 'something'
-        }
-        plugin.provider.request.mockResolvedValueOnce({})
-
-        await plugin.associateWaf()
-
-        expect(plugin.provider.request).not.toHaveBeenCalledWith('CloudFormation', expect.anything(), expect.anything())
-      })
-
-      it('should log info when unable to find REST API ID from CloudFormation stack', async () => {
-        plugin.provider.request.mockResolvedValue({})
-
-        await plugin.associateWaf()
-
-        expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Unable to determine REST API ID'))
-      })
-
-      it('should log info when unable to fund REST API ID from stack outputs', async () => {
-        plugin.provider.request.mockResolvedValueOnce({})
-        plugin.provider.request.mockResolvedValueOnce(mockStackMissingOutputs)
-
-        await plugin.associateWaf()
-
-        expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Unable to determine REST API ID'))
-      })
-
-      it('should log info when unable to find WAF', async () => {
-        plugin.provider.request
-          .mockResolvedValueOnce(mockStackResources)
-          .mockResolvedValueOnce(mockStackOutputs)
-          .mockResolvedValueOnce({})
-
-        await plugin.associateWaf()
-
-        expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Unable to find WAF named'))
-      })
-
-      it('should log error when exception caught', async () => {
-        spy = await setupAwsErrorMessage(plugin)
-        await plugin.associateWaf()
-        expect(spy).toHaveBeenLastCalledWith(expect.stringContaining(AWSErrorMessage))
-      })
-
-      it('should associate WAF', async () => {
-        const mockWebAcls = {
-          WebACLs: [
-            {
-              Name: 'skip-waf-name',
-              ARN: 'skip-waf-arn'
-            },
-            {
-              Name: 'some-waf-name',
-              ARN: 'some-waf-arn'
-            }
-          ]
-        }
-
-        plugin.provider.request
-          .mockResolvedValueOnce(mockStackResources)
-          .mockResolvedValueOnce(mockWebAcls)
-
-        await plugin.associateWaf()
-
-        expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Associating WAF...'))
-      })
-
-      it('should associate WAF with split stacks plugin', async () => {
-        const mockWebAcls = {
-          WebACLs: [
-            {
-              Name: 'skip-waf-name',
-              ARN: 'skip-waf-arn'
-            },
-            {
-              Name: 'some-waf-name',
-              ARN: 'some-waf-arn'
-            }
-          ]
-        }
-
-        plugin.provider.request
-          .mockResolvedValueOnce({})
-          .mockResolvedValueOnce(mockStackOutputs)
-          .mockResolvedValueOnce(mockWebAcls)
-
-        await plugin.associateWaf()
-
-        expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Associating WAF...'))
-      })
-
+      }
+      plugin = new AssociateWafPlugin(serverless, options)
     })
+
+    it('should not lookup REST API ID from CloudFormation stack if specified by provider configuration', async () => {
+      plugin.serverless.service.provider.apiGateway = {
+        restApiId: 'something'
+      }
+      plugin.provider.request.mockResolvedValueOnce({})
+
+      await plugin.associateWaf()
+
+      expect(plugin.provider.request).not.toHaveBeenCalledWith('CloudFormation', expect.anything(), expect.anything())
+    })
+
+    it('should log info when unable to find REST API ID from CloudFormation stack', async () => {
+      plugin.provider.request.mockResolvedValue({})
+
+      await plugin.associateWaf()
+
+      expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Unable to determine REST API ID'))
+    })
+
+    it('should log info when unable to fund REST API ID from stack outputs', async () => {
+      plugin.provider.request.mockResolvedValueOnce({})
+      plugin.provider.request.mockResolvedValueOnce(mockStackMissingOutputs)
+
+      await plugin.associateWaf()
+
+      expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Unable to determine REST API ID'))
+    })
+
+    it('should log info when unable to find WAF', async () => {
+      plugin.provider.request
+        .mockResolvedValueOnce(mockStackResources)
+        .mockResolvedValueOnce(mockStackOutputs)
+        .mockResolvedValueOnce({})
+
+      await plugin.associateWaf()
+
+      expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Unable to find WAF named'))
+    })
+
+    it('should log error when exception caught', async () => {
+      spy = await setupAwsErrorMessage(plugin)
+      await plugin.associateWaf()
+      expect(spy).toHaveBeenLastCalledWith(expect.stringContaining(AWSErrorMessage))
+    })
+
+    it('should associate WAF', async () => {
+      const mockWebAcls = {
+        WebACLs: [
+          {
+            Name: 'skip-waf-name',
+            ARN: 'skip-waf-arn'
+          },
+          {
+            Name: 'some-waf-name',
+            ARN: 'some-waf-arn'
+          }
+        ]
+      }
+
+      plugin.provider.request
+        .mockResolvedValueOnce(mockStackResources)
+        .mockResolvedValueOnce(mockWebAcls)
+
+      await plugin.associateWaf()
+
+      expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Associating WAF...'))
+    })
+
+    it('should associate WAF with split stacks plugin', async () => {
+      const mockWebAcls = {
+        WebACLs: [
+          {
+            Name: 'skip-waf-name',
+            ARN: 'skip-waf-arn'
+          },
+          {
+            Name: 'some-waf-name',
+            ARN: 'some-waf-arn'
+          }
+        ]
+      }
+
+      plugin.provider.request
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce(mockStackOutputs)
+        .mockResolvedValueOnce(mockWebAcls)
+
+      await plugin.associateWaf()
+
+      expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Associating WAF...'))
+    })
+
+  })
   })
 
   describe('disassociateWaf()', () => {
@@ -668,7 +659,7 @@ describe('AssociateWafPlugin', () => {
     })
 
     it('should not disassociate WAF if associated', async () => {
-      const mockWebAcls = {}
+      const mockWebAcls = { }
 
       plugin.provider.request
         .mockResolvedValueOnce(mockStackResources)
@@ -683,21 +674,21 @@ describe('AssociateWafPlugin', () => {
 
   })
 
-  async function setupAwsErrorMessage(plugin) {
+  async function setupAwsErrorMessage(plugin){
     const spy = jest.spyOn(console, 'error')
     plugin.provider.request
       .mockRejectedValueOnce(new Error(AWSErrorMessage))
     return spy
   }
 
-  async function expectDisassociateWafToHaveBeenCalled(plugin) {
+  async function expectDisassociateWafToHaveBeenCalled(plugin){
     plugin.disassociateWaf = jest.fn()
     plugin.disassociateWaf.mockResolvedValueOnce({})
     await plugin.updateWafAssociation()
     expect(plugin.disassociateWaf).toHaveBeenCalled()
   }
 
-  async function expectOutputRestApiIdToHaveBeenCalled(plugin) {
+  async function expectOutputRestApiIdToHaveBeenCalled(plugin){
     plugin.outputRestApiId = jest.fn()
     plugin.outputRestApiId.mockResolvedValueOnce({})
     await plugin.updateCloudFormationTemplate()

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -4,6 +4,11 @@ const AwsProvider = jest.genMockFromModule('serverless/lib/plugins/aws/provider/
 const CLI = jest.genMockFromModule('serverless/lib/classes/CLI')
 
 const AWSErrorMessage = 'Some AWS provider error'
+const WAF_REGIONAL = "WAFRegional"
+const WAF_V2 = "WAFV2"
+const ALLOWED_WAF_VERSIONS = [WAF_REGIONAL, WAF_V2]
+const ALLOWED_WAF_SCOPE = "REGIONAL"
+
 
 describe('AssociateWafPlugin', () => {
   let plugin
@@ -33,6 +38,19 @@ describe('AssociateWafPlugin', () => {
     it('should have access to the serverless instance', () => {
       expect(plugin.serverless).toEqual(serverless)
     })
+
+
+    it('should have access to the serverless instance', () => {
+      expect(plugin.serverless).toEqual(serverless)
+    })
+
+    it(`wafVersion should be one of ${ALLOWED_WAF_VERSIONS}`, () => {
+      expect(ALLOWED_WAF_VERSIONS).toContain(plugin.wafVersion);
+    })
+
+    it(`wafScope should equal ${ALLOWED_WAF_SCOPE}`, () => {
+      expect(plugin.wafScope).toEqual(ALLOWED_WAF_SCOPE)
+    })
   })
 
   describe('without configuration', () => {
@@ -59,7 +77,6 @@ describe('AssociateWafPlugin', () => {
       it('"disassociateWaf()" should be invoked', async () => {
         await expectDisassociateWafToHaveBeenCalled(plugin)
       })
-
     })
 
     describe('with missing object "custom.associateWaf"', () => {
@@ -163,45 +180,201 @@ describe('AssociateWafPlugin', () => {
         await expectDisassociateWafToHaveBeenCalled(plugin)
       })
     })
+
+    describe('with invalid property "custom.associateWaf.version"', () => {
+      beforeEach(() => {
+        serverless.service.custom = {
+          associateWaf: {
+            version: "invalid-version"
+          }
+        }
+        plugin = new AssociateWafPlugin(serverless, options)
+      })
+
+      it('should set hooks if ', () => {
+        expect(plugin.hooks).toHaveProperty('after:deploy:deploy')
+        expect(plugin.hooks).toHaveProperty('before:package:finalize')
+      })
+
+      it('should log info when invalid version configuration exists ', () => {
+        expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Invalid WAF Version Configuration'))
+      })
+
+      it(`wafVersion should equal ${WAF_REGIONAL}`, () => {
+        expect(WAF_REGIONAL).toEqual(plugin.wafVersion);
+      })
+
+
+      it('"outputRestApiId()" should be invoked', async () => {
+        await expectOutputRestApiIdToHaveBeenCalled(plugin)
+      })
+
+      it('"disassociateWaf()" should be invoked', async () => {
+        await expectDisassociateWafToHaveBeenCalled(plugin)
+      })
+    })
+
+    describe('with null property "custom.associateWaf.version"', () => {
+      beforeEach(() => {
+        serverless.service.custom = {
+          associateWaf: {}
+        }
+        serverless.service.provider.compiledCloudFormationTemplate = {
+          Outputs: [
+            {}]
+        }
+        plugin = new AssociateWafPlugin(serverless, options)
+      })
+
+      it('should set hooks if ', () => {
+        expect(plugin.hooks).toHaveProperty('after:deploy:deploy')
+        expect(plugin.hooks).toHaveProperty('before:package:finalize')
+      })
+
+      it(`wafVersion should equal ${WAF_REGIONAL}`, () => {
+        expect(WAF_REGIONAL).toEqual(plugin.wafVersion);
+      })
+
+      it('"outputRestApiId()" should be invoked', async () => {
+        await expectOutputRestApiIdToHaveBeenCalled(plugin)
+      })
+
+      it('"disassociateWaf()" should be invoked', async () => {
+        await expectDisassociateWafToHaveBeenCalled(plugin)
+      })
+    })
+
   })
 
   describe('with configuration', () => {
-    beforeEach(() => {
-      serverless.service.custom = {
-        associateWaf: {
-          name: 'stage-service-name'
+    describe('default configuration', () => {
+      beforeEach(() => {
+        serverless.service.custom = {
+          associateWaf: {
+            name: 'stage-service-name'
+          }
         }
-      }
-      serverless.service.provider.compiledCloudFormationTemplate = {
-        Outputs: [
-          'ApiGatewayRestApiWaf', {Description: 'Rest API Id', Value: 'some-api-rest-id'}]
-      }
-      plugin = new AssociateWafPlugin(serverless, options)
+        serverless.service.provider.compiledCloudFormationTemplate = {
+          Outputs: [
+            'ApiGatewayRestApiWaf', { Description: 'Rest API Id', Value: 'some-api-rest-id' }]
+        }
+        plugin = new AssociateWafPlugin(serverless, options)
+      })
+
+      it('should set config', () => {
+        expect(plugin.config).toBeTruthy()
+      })
+
+      it('should set hooks', () => {
+        expect(plugin.hooks).toHaveProperty('after:deploy:deploy')
+        expect(plugin.hooks).toHaveProperty('before:package:finalize')
+      })
+
+      it('"outputRestApiId()" should be invoked', async () => {
+        await expectOutputRestApiIdToHaveBeenCalled(plugin)
+      })
+
+      it('should output restApiId', () => {
+        plugin.updateCloudFormationTemplate()
+        expect(serverless.service.provider.compiledCloudFormationTemplate.Outputs['ApiGatewayRestApiWaf']).toBeDefined()
+      })
+
+      it('"associateWaf()" should be invoked', async () => {
+        plugin.associateWaf = jest.fn()
+        plugin.associateWaf.mockResolvedValueOnce({})
+        await plugin.updateWafAssociation()
+        expect(plugin.associateWaf).toHaveBeenCalled()
+      })
     })
 
-    it('should set config', () => {
-      expect(plugin.config).toBeTruthy()
+    describe('with adding property "custom.associateWaf.version" === "V2" ', () => {
+      beforeEach(() => {
+        serverless.service.custom = {
+          associateWaf: {
+            name: 'stage-service-name',
+            version: "V2"
+          }
+        }
+        serverless.service.provider.compiledCloudFormationTemplate = {
+          Outputs: [
+            'ApiGatewayRestApiWaf', { Description: 'Rest API Id', Value: 'some-api-rest-id' }]
+        }
+        plugin = new AssociateWafPlugin(serverless, options)
+      })
+
+      it('should set config', () => {
+        expect(plugin.config).toBeTruthy()
+      })
+
+      it(`wafVersion should be ${WAF_V2}`, () => {
+        expect(plugin.wafVersion).toEqual(WAF_V2);
+      })
+
+      it('should set hooks', () => {
+        expect(plugin.hooks).toHaveProperty('after:deploy:deploy')
+        expect(plugin.hooks).toHaveProperty('before:package:finalize')
+      })
+
+      it('"outputRestApiId()" should be invoked', async () => {
+        await expectOutputRestApiIdToHaveBeenCalled(plugin)
+      })
+
+      it('should output restApiId', () => {
+        plugin.updateCloudFormationTemplate()
+        expect(serverless.service.provider.compiledCloudFormationTemplate.Outputs['ApiGatewayRestApiWaf']).toBeDefined()
+      })
+
+      it('"associateWaf()" should be invoked', async () => {
+        plugin.associateWaf = jest.fn()
+        plugin.associateWaf.mockResolvedValueOnce({})
+        await plugin.updateWafAssociation()
+        expect(plugin.associateWaf).toHaveBeenCalled()
+      })
     })
 
-    it('should set hooks', () => {
-      expect(plugin.hooks).toHaveProperty('after:deploy:deploy')
-      expect(plugin.hooks).toHaveProperty('before:package:finalize')
-    })
+    describe('with adding property "custom.associateWaf.version" !== "V2" ', () => {
+      beforeEach(() => {
+        serverless.service.custom = {
+          associateWaf: {
+            name: 'stage-service-name',
+            version: "default-version"
+          }
+        }
+        serverless.service.provider.compiledCloudFormationTemplate = {
+          Outputs: [
+            'ApiGatewayRestApiWaf', { Description: 'Rest API Id', Value: 'some-api-rest-id' }]
+        }
+        plugin = new AssociateWafPlugin(serverless, options)
+      })
 
-    it('"outputRestApiId()" should be invoked', async () => {
-      await expectOutputRestApiIdToHaveBeenCalled(plugin)
-    })
+      it('should set config', () => {
+        expect(plugin.config).toBeTruthy()
+      })
 
-    it('should output restApiId', () => {
-      plugin.updateCloudFormationTemplate()
-      expect(serverless.service.provider.compiledCloudFormationTemplate.Outputs['ApiGatewayRestApiWaf']).toBeDefined()
-    })
+      it(`wafVersion should be ${WAF_REGIONAL}`, () => {
+        expect(plugin.wafVersion).toEqual(WAF_REGIONAL);
+      })
 
-    it('"associateWaf()" should be invoked', async () => {
-      plugin.associateWaf = jest.fn()
-      plugin.associateWaf.mockResolvedValueOnce({})
-      await plugin.updateWafAssociation()
-      expect(plugin.associateWaf).toHaveBeenCalled()
+      it('should set hooks', () => {
+        expect(plugin.hooks).toHaveProperty('after:deploy:deploy')
+        expect(plugin.hooks).toHaveProperty('before:package:finalize')
+      })
+
+      it('"outputRestApiId()" should be invoked', async () => {
+        await expectOutputRestApiIdToHaveBeenCalled(plugin)
+      })
+
+      it('should output restApiId', () => {
+        plugin.updateCloudFormationTemplate()
+        expect(serverless.service.provider.compiledCloudFormationTemplate.Outputs['ApiGatewayRestApiWaf']).toBeDefined()
+      })
+
+      it('"associateWaf()" should be invoked', async () => {
+        plugin.associateWaf = jest.fn()
+        plugin.associateWaf.mockResolvedValueOnce({})
+        await plugin.updateWafAssociation()
+        expect(plugin.associateWaf).toHaveBeenCalled()
+      })
     })
 
   })
@@ -245,108 +418,216 @@ describe('AssociateWafPlugin', () => {
   }
 
   describe('associateWaf()', () => {
-
-    beforeEach(() => {
-      serverless.service.custom = {
-        associateWaf: {
-          name: 'some-waf-name'
+    describe("associate Waf regional", () => {
+      beforeEach(() => {
+        serverless.service.custom = {
+          associateWaf: {
+            name: 'some-waf-name'
+          }
         }
-      }
-      plugin = new AssociateWafPlugin(serverless, options)
+        plugin = new AssociateWafPlugin(serverless, options)
+      })
+
+      it('should not lookup REST API ID from CloudFormation stack if specified by provider configuration', async () => {
+        plugin.serverless.service.provider.apiGateway = {
+          restApiId: 'something'
+        }
+        plugin.provider.request.mockResolvedValueOnce({})
+
+        await plugin.associateWaf()
+
+        expect(plugin.provider.request).not.toHaveBeenCalledWith('CloudFormation', expect.anything(), expect.anything())
+      })
+
+      it('should log info when unable to find REST API ID from CloudFormation stack', async () => {
+        plugin.provider.request.mockResolvedValue({})
+
+        await plugin.associateWaf()
+
+        expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Unable to determine REST API ID'))
+      })
+
+      it('should log info when unable to fund REST API ID from stack outputs', async () => {
+        plugin.provider.request.mockResolvedValueOnce({})
+        plugin.provider.request.mockResolvedValueOnce(mockStackMissingOutputs)
+
+        await plugin.associateWaf()
+
+        expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Unable to determine REST API ID'))
+      })
+
+      it('should log info when unable to find WAF', async () => {
+        plugin.provider.request
+          .mockResolvedValueOnce(mockStackResources)
+          .mockResolvedValueOnce(mockStackOutputs)
+          .mockResolvedValueOnce({})
+
+        await plugin.associateWaf()
+
+        expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Unable to find WAF named'))
+      })
+
+      it('should log error when exception caught', async () => {
+        spy = await setupAwsErrorMessage(plugin)
+        await plugin.associateWaf()
+        expect(spy).toHaveBeenLastCalledWith(expect.stringContaining(AWSErrorMessage))
+      })
+
+      it('should associate WAF', async () => {
+        const mockWebAcls = {
+          WebACLs: [
+            {
+              Name: 'skip-waf-name',
+              WebACLId: 'skip-waf-id'
+            },
+            {
+              Name: 'some-waf-name',
+              WebACLId: 'some-waf-id'
+            }
+          ]
+        }
+
+        plugin.provider.request
+          .mockResolvedValueOnce(mockStackResources)
+          .mockResolvedValueOnce(mockWebAcls)
+
+        await plugin.associateWaf()
+
+        expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Associating WAF...'))
+      })
+
+      it('should associate WAF with split stacks plugin', async () => {
+        const mockWebAcls = {
+          WebACLs: [
+            {
+              Name: 'skip-waf-name',
+              WebACLId: 'skip-waf-id'
+            },
+            {
+              Name: 'some-waf-name',
+              WebACLId: 'some-waf-id'
+            }
+          ]
+        }
+
+        plugin.provider.request
+          .mockResolvedValueOnce({})
+          .mockResolvedValueOnce(mockStackOutputs)
+          .mockResolvedValueOnce(mockWebAcls)
+
+        await plugin.associateWaf()
+
+        expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Associating WAF...'))
+      })
     })
 
-    it('should not lookup REST API ID from CloudFormation stack if specified by provider configuration', async () => {
-      plugin.serverless.service.provider.apiGateway = {
-        restApiId: 'something'
-      }
-      plugin.provider.request.mockResolvedValueOnce({})
 
-      await plugin.associateWaf()
 
-      expect(plugin.provider.request).not.toHaveBeenCalledWith('CloudFormation', expect.anything(), expect.anything())
-    })
+    describe("associate Waf V2", () => {
+      beforeEach(() => {
+        serverless.service.custom = {
+          associateWaf: {
+            name: 'some-waf-name',
+            version: "V2"
+          }
+        }
+        plugin = new AssociateWafPlugin(serverless, options)
+      })
 
-    it('should log info when unable to find REST API ID from CloudFormation stack', async () => {
-      plugin.provider.request.mockResolvedValue({})
+      it('should not lookup REST API ID from CloudFormation stack if specified by provider configuration', async () => {
+        plugin.serverless.service.provider.apiGateway = {
+          restApiId: 'something'
+        }
+        plugin.provider.request.mockResolvedValueOnce({})
 
-      await plugin.associateWaf()
+        await plugin.associateWaf()
 
-      expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Unable to determine REST API ID'))
-    })
+        expect(plugin.provider.request).not.toHaveBeenCalledWith('CloudFormation', expect.anything(), expect.anything())
+      })
 
-    it('should log info when unable to fund REST API ID from stack outputs', async () => {
-      plugin.provider.request.mockResolvedValueOnce({})
-      plugin.provider.request.mockResolvedValueOnce(mockStackMissingOutputs)
+      it('should log info when unable to find REST API ID from CloudFormation stack', async () => {
+        plugin.provider.request.mockResolvedValue({})
 
-      await plugin.associateWaf()
+        await plugin.associateWaf()
 
-      expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Unable to determine REST API ID'))
+        expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Unable to determine REST API ID'))
+      })
+
+      it('should log info when unable to fund REST API ID from stack outputs', async () => {
+        plugin.provider.request.mockResolvedValueOnce({})
+        plugin.provider.request.mockResolvedValueOnce(mockStackMissingOutputs)
+
+        await plugin.associateWaf()
+
+        expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Unable to determine REST API ID'))
+      })
+
+      it('should log info when unable to find WAF', async () => {
+        plugin.provider.request
+          .mockResolvedValueOnce(mockStackResources)
+          .mockResolvedValueOnce(mockStackOutputs)
+          .mockResolvedValueOnce({})
+
+        await plugin.associateWaf()
+
+        expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Unable to find WAF named'))
+      })
+
+      it('should log error when exception caught', async () => {
+        spy = await setupAwsErrorMessage(plugin)
+        await plugin.associateWaf()
+        expect(spy).toHaveBeenLastCalledWith(expect.stringContaining(AWSErrorMessage))
+      })
+
+      it('should associate WAF', async () => {
+        const mockWebAcls = {
+          WebACLs: [
+            {
+              Name: 'skip-waf-name',
+              ARN: 'skip-waf-arn'
+            },
+            {
+              Name: 'some-waf-name',
+              ARN: 'some-waf-arn'
+            }
+          ]
+        }
+
+        plugin.provider.request
+          .mockResolvedValueOnce(mockStackResources)
+          .mockResolvedValueOnce(mockWebAcls)
+
+        await plugin.associateWaf()
+
+        expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Associating WAF...'))
+      })
+
+      it('should associate WAF with split stacks plugin', async () => {
+        const mockWebAcls = {
+          WebACLs: [
+            {
+              Name: 'skip-waf-name',
+              ARN: 'skip-waf-arn'
+            },
+            {
+              Name: 'some-waf-name',
+              ARN: 'some-waf-arn'
+            }
+          ]
+        }
+
+        plugin.provider.request
+          .mockResolvedValueOnce({})
+          .mockResolvedValueOnce(mockStackOutputs)
+          .mockResolvedValueOnce(mockWebAcls)
+
+        await plugin.associateWaf()
+
+        expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Associating WAF...'))
+      })
+
     })
   })
-
-    it('should log info when unable to find WAF', async () => {
-      plugin.provider.request
-        .mockResolvedValueOnce(mockStackResources)
-        .mockResolvedValueOnce(mockStackOutputs)
-        .mockResolvedValueOnce({})
-
-      await plugin.associateWaf()
-
-      expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Unable to find WAF named'))
-    })
-
-    it('should log error when exception caught', async () => {
-      spy = await setupAwsErrorMessage(plugin)
-      await plugin.associateWaf()
-      expect(spy).toHaveBeenLastCalledWith(expect.stringContaining(AWSErrorMessage))
-    })
-
-    it('should associate WAF', async () => {
-      const mockWebAcls = {
-        WebACLs: [
-          {
-            Name: 'skip-waf-name',
-            WebACLId: 'skip-waf-id'
-          },
-          {
-            Name: 'some-waf-name',
-            WebACLId: 'some-waf-id'
-          }
-        ]
-      }
-
-      plugin.provider.request
-        .mockResolvedValueOnce(mockStackResources)
-        .mockResolvedValueOnce(mockWebAcls)
-
-      await plugin.associateWaf()
-
-      expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Associating WAF...'))
-    })
-
-    it('should associate WAF with split stacks plugin', async () => {
-      const mockWebAcls = {
-        WebACLs: [
-          {
-            Name: 'skip-waf-name',
-            WebACLId: 'skip-waf-id'
-          },
-          {
-            Name: 'some-waf-name',
-            WebACLId: 'some-waf-id'
-          }
-        ]
-      }
-
-      plugin.provider.request
-        .mockResolvedValueOnce({})
-        .mockResolvedValueOnce(mockStackOutputs)
-        .mockResolvedValueOnce(mockWebAcls)
-
-      await plugin.associateWaf()
-
-      expect(plugin.serverless.cli.log).toHaveBeenLastCalledWith(expect.stringContaining('Associating WAF...'))
-    })
 
   describe('disassociateWaf()', () => {
     beforeEach(() => {
@@ -387,7 +668,7 @@ describe('AssociateWafPlugin', () => {
     })
 
     it('should not disassociate WAF if associated', async () => {
-      const mockWebAcls = { }
+      const mockWebAcls = {}
 
       plugin.provider.request
         .mockResolvedValueOnce(mockStackResources)
@@ -402,21 +683,21 @@ describe('AssociateWafPlugin', () => {
 
   })
 
-  async function setupAwsErrorMessage(plugin){
+  async function setupAwsErrorMessage(plugin) {
     const spy = jest.spyOn(console, 'error')
     plugin.provider.request
       .mockRejectedValueOnce(new Error(AWSErrorMessage))
     return spy
   }
 
-  async function expectDisassociateWafToHaveBeenCalled(plugin){
+  async function expectDisassociateWafToHaveBeenCalled(plugin) {
     plugin.disassociateWaf = jest.fn()
     plugin.disassociateWaf.mockResolvedValueOnce({})
     await plugin.updateWafAssociation()
     expect(plugin.disassociateWaf).toHaveBeenCalled()
   }
 
-  async function expectOutputRestApiIdToHaveBeenCalled(plugin){
+  async function expectOutputRestApiIdToHaveBeenCalled(plugin) {
     plugin.outputRestApiId = jest.fn()
     plugin.outputRestApiId.mockResolvedValueOnce({})
     await plugin.updateCloudFormationTemplate()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-associate-waf",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
In response to [Support for WAFv2 #16](https://github.com/MikeSouza/serverless-associate-waf/issues/16)
Added two additional config parameters:

- version:  [V2, Regional] 
version defaults to Regional

- scope:  [REGIONAL, CLOUDFRONT]
scope defaults to REGIONAL

