### PR TITLE
Fix handle cases when existing api gateway id

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,7 @@ class AssociateWafPlugin {
     this.hooks = {}
 
     this.hooks['after:deploy:deploy'] = this.updateWafAssociation.bind(this)
-    this.hooks['before:package:finalize'] = this.updateCloudFormationTemplate.bind(this)
+    this.hooks['before:package:finalize'] = this.prepareCFUpdate.bind(this)
   }
 
   verifyValidWafConfig() {
@@ -39,6 +39,13 @@ class AssociateWafPlugin {
 
   getApiGatewayStageArn(restApiId) {
     return `arn:aws:apigateway:${this.provider.getRegion()}::/restapis/${restApiId}/stages/${this.provider.getStage()}`
+  }
+
+  prepareCFUpdate() {
+    const isApiGatewayExternal = this.serverless.provider.apiGateway.restApiId ? true : false;
+    if (!isApiGatewayExternal) {
+      this.updateCloudFormationTemplate()
+    }
   }
 
   updateCloudFormationTemplate() {


### PR DESCRIPTION
Handle cases when existing api gateway id is passed as parameter to serverless. Currently when passing the api gateway id, I'm unable to associate WAF.

Error - `The CloudFormation template is invalid: Unresolved resource dependencies [ApiGatewayRestApi] in the Outputs block of the template`