### PR TITLE
Use API Gateway stage if provided

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,7 @@ class AssociateWafPlugin {
   }
 
   getApiGatewayStageArn(restApiId) {
-    return `arn:aws:apigateway:${this.provider.getRegion()}::/restapis/${restApiId}/stages/${this.provider.getStage()}`
+    return `arn:aws:apigateway:${this.provider.getRegion()}::/restapis/${restApiId}/stages/${this.provider.getApiGatewayStage()}`
   }
 
   updateCloudFormationTemplate() {


### PR DESCRIPTION
For REST API, there is an option to provide a [custom stage name](https://www.serverless.com/framework/docs/providers/aws/events/apigateway#providing-a-custom-stage-name).
Currently, this plugin assumes that the API Gateway stage is the same as the deployment stage, i.e. `serverless deploy --stage dev`.

References:
[this.provider.getApiGatewayStage()](https://github.com/serverless/serverless/blob/main/lib/plugins/aws/provider.js#L1977)